### PR TITLE
Fix syntax error in cvs.rb

### DIFF
--- a/lib/puppet/provider/vcsrepo/cvs.rb
+++ b/lib/puppet/provider/vcsrepo/cvs.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:vcsrepo).provide(:cvs, parent: Puppet::Provider::Vcsrepo) do
       if File.exist?(tag_file)
         contents = File.read(tag_file).strip
         # NOTE: Doesn't differentiate between N and T entries
-        @rev = contents[1..]
+        @rev = contents[1..-1]
       else
         @rev = 'HEAD'
       end


### PR DESCRIPTION
## Summary
A simple syntax error that should be fixed

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)